### PR TITLE
Add subscription_plan_changed event to webhook event types

### DIFF
--- a/src/webhooks/types.ts
+++ b/src/webhooks/types.ts
@@ -21,6 +21,7 @@ type Events =
   | "subscription_payment_failed"
   | "subscription_payment_recovered"
   | "subscription_payment_refunded"
+  | "subscription_plan_changed"
   | "license_key_created"
   | "license_key_updated";
 


### PR DESCRIPTION
Add `subscription_plan_changed` event to webhook event types

Despite being very useful for SaaS subscription management, this webhook event name is not listed in the lemonsqueezy library nor in the documentation for some reason. Yet the webhook is supported by Lemon Squeezy as you can enable it in the app dashboard (see screenshot below):

<img width="529" alt="image" src="https://github.com/user-attachments/assets/900b9eb2-5d0d-489c-9d1b-94266cd03dfe" />

Could the documentation be updated as well to include this event?

Thanks!